### PR TITLE
Using nested objects - Works fine - Tested using Ring 1.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,20 +71,25 @@ You can print all the colors info like this:
 ? colors.Print()
 ```
 
-# Warining:
-You can't nest `defObj` directly, because there is a bug in Ring regarding calling methods with list param inside another listt. This will not work:
+# Nested Objects:
+
+Example:
+
 ```ring
 y = defobj([
    :a = defobj([
       :b = 1
    ])
 ])
+? y.a.b
 ```
 
-But this will work:
+Example:
+
 ```ring
 x = defobj([:b = 1])
 y = defobj([:a = x])
+? y.a.b
 ```
 
 # Hope:

--- a/Sample2.ring
+++ b/Sample2.ring
@@ -1,0 +1,8 @@
+load "dynobj.ring"
+
+y = defobj([
+   :a = defobj([
+      :b = 1
+   ])
+])
+? y.a.b


### PR DESCRIPTION
Hello Eng. Mohammed

This is an update to the README file.
Where definition of nested objects already works without problems.

Tested using Ring 1.19

Also, Added Sample2.ring which contains your example about this feature.

Greetings,
Mahmoud